### PR TITLE
Handle media player errors in audio announce pane

### DIFF
--- a/panes.cpp
+++ b/panes.cpp
@@ -376,7 +376,11 @@ AudioAnnouncePane::AudioAnnouncePane(const QString &text,const QString &path,QWi
 	audioPlayer->setMedia(QUrl::fromLocalFile(path));
 	connect(audioPlayer,&QMediaPlayer::stateChanged,[this](QMediaPlayer::State state) {
 		if (state == QMediaPlayer::StoppedState) emit Finished();
-	}); // TODO: report loading failures to status section of chat pane
+	});
+	connect(audioPlayer,QOverload<QMediaPlayer::Error>::of(&QMediaPlayer::error),[this](QMediaPlayer::Error error) {
+		if (error != QMediaPlayer::NoError) emit Error(QString("Audio announcement error: %1").arg(audioPlayer->errorString()));
+		emit Finished();
+	});
 }
 
 /*!
@@ -385,6 +389,7 @@ AudioAnnouncePane::AudioAnnouncePane(const QString &text,const QString &path,QWi
  */
 void AudioAnnouncePane::Show()
 {
+	if (audioPlayer->error() != QMediaPlayer::NoError) return;
 	Polish();
 	show();
 	audioPlayer->play(); // FIXME: catch errors above and don't play if the file failed to load

--- a/panes.h
+++ b/panes.h
@@ -101,6 +101,8 @@ public:
 	void Show() override;
 protected:
 	QMediaPlayer *audioPlayer;
+signals:
+	void Error(const QString &error);
 };
 
 class ImageAnnouncePane : public AnnouncePane

--- a/window.cpp
+++ b/window.cpp
@@ -226,8 +226,10 @@ void Window::FollowChat()
 	connect(chatMessageReceiver,&ChatMessageReceiver::PlayVideo,[this](const QString &path) {
 		StageEphemeralPane(new VideoPane(path));
 	});
-	connect(chatMessageReceiver,&ChatMessageReceiver::PlayAudio,[this](const QString &user,const QString &message,const QString &path) {
-		StageEphemeralPane(new AudioAnnouncePane(QString("**%1**\n\n%2").arg(user,message),path));
+	connect(chatMessageReceiver,&ChatMessageReceiver::PlayAudio,[this,chatPane](const QString &user,const QString &message,const QString &path) {
+		AudioAnnouncePane *audioAnnouncePane=new AudioAnnouncePane(QString("<h2>%1</h2><br><br>%2").arg(user,message),path);
+		connect(audioAnnouncePane,&AudioAnnouncePane::Error,chatPane,&ChatPane::Alert);
+		StageEphemeralPane(audioAnnouncePane);
 	});
 
 	connect(chatMessageReceiver,&ChatMessageReceiver::DispatchCommand,[this,chatPane](const Command &command) {


### PR DESCRIPTION
Fixes issue #5

Display the error message and refuse to show the pane instead of showing it and waiting for a state change that never happens.